### PR TITLE
With the release of puppet-lint 2.0.0, support ~>2.0 versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: bundler
 script:
 - bundle exec rake spec
 rvm:
-- 1.8.7
 - 1.9.3
 - 2.0.0
 - 2.1.5

--- a/puppet-lint-empty_string-check.gemspec
+++ b/puppet-lint-empty_string-check.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-empty_string-check'
-  spec.version     = '0.2.1'
+  spec.version     = '0.2.2'
   spec.homepage    = 'https://github.com/puppet-community/puppet-lint-empty_string-check'
   spec.license     = 'Apache-2.0'
   spec.author      = 'Puppet Community'
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     A puppet-lint plugin to check for variables assigned to the empty string.
   EOF
 
-  spec.add_dependency             'puppet-lint', '~> 1.0'
+  spec.add_dependency             'puppet-lint', '>= 1.0', '< 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'


### PR DESCRIPTION
Many people are using puppet-lint from git head, and have been for a while. puppet-lint 2.0.0 was published today, with no actual changes other than the version number, but it breaks checks that specified `~>1.0`.